### PR TITLE
Optimize portfolio loading performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mayank - Video Editor Portfolio</title>
-      <link rel="shortcut icon" href="./img/20b11aa1187ad281328ff924a4282e72.jpg" type="image/x-icon">
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="shortcut icon" href="./img/20b11aa1187ad281328ff924a4282e72.jpg" type="image/x-icon">
+    <link rel="preconnect" href="https://cdn.tailwindcss.com" crossorigin>
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+    <script src="https://cdn.tailwindcss.com" defer></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
     <style>
         /* Professional Red & Black Theme */
@@ -683,8 +685,8 @@
                 <!-- Video Card 1 -->
                 <div class="video-card" data-category="commercial">
                     <div style="position: relative;">
-                        <iframe style="width: 100%; aspect-ratio: 16/9;" 
-                            src="https://drive.google.com/file/d/1J-lzV0mRQPg0o7aVW1rd9JLAmrZxOLXU/preview" 
+                        <iframe style="width: 100%; aspect-ratio: 16/9;"
+                            src="https://drive.google.com/file/d/1J-lzV0mRQPg0o7aVW1rd9JLAmrZxOLXU/preview" loading="lazy"
                             allow="autoplay" frameborder="0" allowfullscreen></iframe>
                     </div>
                     <div style="padding: 1.5rem;">
@@ -696,7 +698,7 @@
                 <div class="video-card" data-category="social">
                     <div style="position: relative;">
                         <iframe style="width: 100%; aspect-ratio: 16/9;" 
-                            src="https://drive.google.com/file/d/15zbB08wp1zz3UJjVfzccHLau54BV2GfX/preview" 
+                            src="https://drive.google.com/file/d/15zbB08wp1zz3UJjVfzccHLau54BV2GfX/preview" loading="lazy"
                             allow="autoplay" frameborder="0" allowfullscreen></iframe>
                     </div>
                     <div style="padding: 1.5rem;">
@@ -708,7 +710,7 @@
                 <div class="video-card" data-category="social">
                     <div style="position: relative;">
                         <iframe style="width: 100%; aspect-ratio: 16/9;" 
-                            src="https://drive.google.com/file/d/1LXWMLxp04F9lOlI_f6U1jC9z7O-C897B/preview" 
+                            src="https://drive.google.com/file/d/1LXWMLxp04F9lOlI_f6U1jC9z7O-C897B/preview" loading="lazy"
                             allow="autoplay" frameborder="0" allowfullscreen></iframe>
                     </div>
                     <div style="padding: 1.5rem;">
@@ -719,7 +721,7 @@
                 <div class="video-card" data-category="social">
                     <div style="position: relative;">
                         <iframe style="width: 100%; aspect-ratio: 16/9;" 
-                            src="https://drive.google.com/file/d/1LekGCJzv1B0XeapJ0EpGnidPRpUoIiau/preview" 
+                            src="https://drive.google.com/file/d/1LekGCJzv1B0XeapJ0EpGnidPRpUoIiau/preview" loading="lazy"
                             allow="autoplay" frameborder="0" allowfullscreen></iframe>
                     </div>
                     <div style="padding: 1.5rem;">
@@ -731,7 +733,7 @@
                 <div class="video-card" data-category="social">
                     <div style="position: relative;">
                         <iframe style="width: 100%; aspect-ratio: 16/9;" 
-                            src="https://drive.google.com/file/d/1Q9HoK_TWjZUEB1rfgS57yDpBQNQCl7Id/preview" 
+                            src="https://drive.google.com/file/d/1Q9HoK_TWjZUEB1rfgS57yDpBQNQCl7Id/preview" loading="lazy"
                             allow="autoplay" frameborder="0" allowfullscreen></iframe>
                     </div>
                     <div style="padding: 1.5rem;">
@@ -743,7 +745,7 @@
                 <div class="video-card" data-category="youtube">
                     <div style="position: relative;">
                         <iframe style="width: 100%; aspect-ratio: 16/9;" 
-                            src="https://drive.google.com/file/d/1CtWtJMXGE4jU66h2J8fUh7N5_9FWtiNb/preview" 
+                            src="https://drive.google.com/file/d/1CtWtJMXGE4jU66h2J8fUh7N5_9FWtiNb/preview" loading="lazy"
                             allow="autoplay" frameborder="0" allowfullscreen></iframe>
                     </div>
                     <div style="padding: 1.5rem;">
@@ -755,7 +757,7 @@
                 <div class="video-card" data-category="social">
                     <div style="position: relative;">
                         <iframe style="width: 100%; aspect-ratio: 16/9;" 
-                            src="https://drive.google.com/file/d/1saOT4R3gBM5HdKOwB5NM1bfoddRh2cSB/preview" 
+                            src="https://drive.google.com/file/d/1saOT4R3gBM5HdKOwB5NM1bfoddRh2cSB/preview" loading="lazy"
                             allow="autoplay" frameborder="0" allowfullscreen></iframe>
                     </div>
                     <div style="padding: 1.5rem;">
@@ -767,7 +769,7 @@
                 <div class="video-card" data-category="social">
                     <div style="position: relative;">
                         <iframe style="width: 100%; aspect-ratio: 16/9;" 
-                            src="https://drive.google.com/file/d/1pAAImn2FL5oqdrmv-vpsiCaiwNagrRoi/preview" 
+                            src="https://drive.google.com/file/d/1pAAImn2FL5oqdrmv-vpsiCaiwNagrRoi/preview" loading="lazy"
                             allow="autoplay" frameborder="0" allowfullscreen></iframe>
                     </div>
                     <div style="padding: 1.5rem;">
@@ -779,7 +781,7 @@
                 <div class="video-card" data-category="commercial">
                     <div style="position: relative;">
                         <iframe style="width: 100%; aspect-ratio: 16/9;" 
-                            src="https://drive.google.com/file/d/1oqACvpjkNtW5U7RjBec13Xn3wTmAjYDD/preview" 
+                            src="https://drive.google.com/file/d/1oqACvpjkNtW5U7RjBec13Xn3wTmAjYDD/preview" loading="lazy"
                             allow="autoplay" frameborder="0" allowfullscreen></iframe>
                     </div>
                     <div style="padding: 1.5rem;">
@@ -1098,13 +1100,15 @@
 
         // Navigation background on scroll
         const nav = document.querySelector('.nav-fixed');
-        window.addEventListener('scroll', () => {
-            if (window.scrollY > 50) {
-                nav.style.background = 'rgba(0, 0, 0, 0.95)';
-            } else {
-                nav.style.background = 'rgba(0, 0, 0, 0.9)';
-            }
-        });
+        if (nav) {
+            window.addEventListener('scroll', () => {
+                if (window.scrollY > 50) {
+                    nav.style.background = 'rgba(0, 0, 0, 0.95)';
+                } else {
+                    nav.style.background = 'rgba(0, 0, 0, 0.9)';
+                }
+            }, { passive: true });
+        }
 
         // Play button functionality
         document.querySelectorAll('.video-overlay button').forEach(btn => {


### PR DESCRIPTION
## Summary
- add preconnect hints and defer the Tailwind CDN script to reduce render-blocking requests
- lazy load embedded portfolio iframes so videos download only when scrolled into view
- mark the navigation scroll listener as passive to avoid interfering with smooth scrolling

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68ca4d9b02c883289ec974572d9d9bda